### PR TITLE
Fix authentication issues in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: checkout repo
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.PAT }}
       - name: create and activate env
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -53,7 +55,7 @@ jobs:
             cd docs && python -m sphinx . _build/html -b html && cd ..
             rm -Rf gammapy-datasets
       - name: commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4.1.6
+        uses: stefanzweifel/git-auto-commit-action@v4
         if: github.event.pull_request.merged == true
         with:
           commit_author: GitHub Actions <actions@github.com>


### PR DESCRIPTION
This PR tries to fix authentication issues for our Github actions workflow, which automatically commits the docs built when a contribution is accepted and merged.

See https://github.com/stefanzweifel/git-auto-commit-action#action-does-not-push-commit-to-repository-authentication-issue