### PR TITLE
Update CI to use mambaforge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
       - name: create and activate env
         uses: conda-incubator/setup-miniconda@v2
         with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
           activate-environment: gammapy-recipes
           environment-file: environment.yml
           auto-update-conda: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: ci
 on:
-  push
+  pull-request:
+    types: [opened, synchronize, reopened, closed]
 jobs:
   process:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: ci
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
+  push
 jobs:
   process:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: ci
 on:
-  pull-request:
+  pull_request:
     types: [opened, synchronize, reopened, closed]
 jobs:
   process:


### PR DESCRIPTION
The CI is currently hanging during conda environment creation. This PR changes the option to use `Mambaforge` instead.
